### PR TITLE
Update composer.json

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -29,7 +29,7 @@
     },
     "require": {
         "php": ">=7.0",
-        "winter/wn-user-plugin": "^2.0",
+        "winter/wn-user-plugin": "^2.0.0",
         "composer/installers": "~1.0"
     },
     "extra": {

--- a/composer.json
+++ b/composer.json
@@ -29,7 +29,7 @@
     },
     "require": {
         "php": ">=7.0",
-        "winter/wn-user-plugin": "dev-main",
+        "winter/wn-user-plugin": "^2.0",
         "composer/installers": "~1.0"
     },
     "extra": {


### PR DESCRIPTION
If require `"winter/wn-user-plugin": "dev-main"`
plugin is not installed through the composer.

> Your requirements could not be resolved to an installable set of packages.
> 
>   Problem 1
>     - Root composer.json requires winter/wn-forum-plugin ^2.0 -> satisfiable by winter/wn-forum-plugin[v2.0.0].
>     - winter/wn-forum-plugin v2.0.0 requires winter/wn-user-plugin dev-main -> found winter/wn-user-plugin[dev-main] but it conflicts with your root composer.json require 
> (^2.0).
> 
> Use the option --with-all-dependencies (-W) to allow upgrades, downgrades and removals for packages currently locked to specific versions.
> 
> Installation failed, reverting ./composer.json and ./composer.lock to their original content.