### PR TITLE
Add postUpdate and postDelete events to Topic component

### DIFF
--- a/components/Topic.php
+++ b/components/Topic.php
@@ -427,6 +427,12 @@ class Topic extends ComponentBase
         }
         elseif ($mode == 'delete') {
             $post->delete();
+
+            /*
+             * Extensbility
+             */
+            Event::fire('winter.forum.topic.postDelete', [$this, $post]);
+            $this->fireEvent('topic.postDelete', [$post]);
         }
 
         $this->page['mode'] = $mode;

--- a/components/Topic.php
+++ b/components/Topic.php
@@ -418,6 +418,12 @@ class Topic extends ComponentBase
                 $topic->fill(['subject' => post('subject')]);
                 $topic->save();
             }
+
+            /*
+             * Extensbility
+             */
+            Event::fire('winter.forum.topic.post-update', [$this, $post]);
+            $this->fireEvent('topic.post-update', [$post]);
         }
         elseif ($mode == 'delete') {
             $post->delete();

--- a/components/Topic.php
+++ b/components/Topic.php
@@ -422,8 +422,8 @@ class Topic extends ComponentBase
             /*
              * Extensbility
              */
-            Event::fire('winter.forum.topic.post-update', [$this, $post]);
-            $this->fireEvent('topic.post-update', [$post]);
+            Event::fire('winter.forum.topic.postUpdate', [$this, $post]);
+            $this->fireEvent('topic.postUpdate', [$post]);
         }
         elseif ($mode == 'delete') {
             $post->delete();


### PR DESCRIPTION
Currently building a "content_images" plugin for posts, I need to postpone the file relationship creation using deferred bindings on post create and update form events.

I felt like the post-update event was missing, the same way topic.create and topic.post already exist:
https://github.com/wintercms/wn-forum-plugin/blob/ffec47d4e4bd738d83076d0de6e96758623111c2/components/Topic.php#L337-L341
https://github.com/wintercms/wn-forum-plugin/blob/ffec47d4e4bd738d83076d0de6e96758623111c2/components/Topic.php#L375-L379

