### PR TITLE
SQL performance improvement on TopicFollow::check

### DIFF
--- a/models/TopicFollow.php
+++ b/models/TopicFollow.php
@@ -71,7 +71,7 @@ class TopicFollow extends Model
      */
     public static function check($topic, $member)
     {
-        return self::where('member_id', $member->id)->where('topic_id', $topic->id)->count() > 0;
+        return self::where('member_id', $member->id)->where('topic_id', $topic->id)->exists();
     }
 
     /**


### PR DESCRIPTION
The EXISTS sql statement will return true at the first existing value where the COUNT will uselessly continue to loop through the whole table which is inaccurate for this use case.